### PR TITLE
sdk: share streams between callers

### DIFF
--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -1,34 +1,45 @@
-public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}Proto.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}Proto.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}({% for param in params %}{{ param.type }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
+private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}Proto.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}Proto.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }} = create{{ name.upper_camel_case }}();
+
+private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}Proto.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}Proto.{{ return_type.name }}{% endif %}> create{{ name.upper_camel_case }}() {
   {{ plugin_name.upper_camel_case }}Proto.Subscribe{{ name.upper_camel_case }}Request request
       = {{ plugin_name.upper_camel_case }}Proto.Subscribe{{ name.upper_camel_case }}Request.newBuilder().build();
 
-  return Flowable.create(emitter -> {
-    scheduler.scheduleDirect(() -> {
-      stub.subscribe{{ name.upper_camel_case }}(request,
-          new StreamObserver<{{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response>() {
+  Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}Proto.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}Proto.{{ return_type.name }}{% endif %}> flowable
+    = Flowable.create(emitter -> {
+      scheduler.scheduleDirect(() -> {
+        stub.subscribe{{ name.upper_camel_case }}(request,
+            new StreamObserver<{{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response>() {
 
-        @Override
-        public void onNext({{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response value) {
-          {% if has_result %}
-          {% endif %}
+          @Override
+          public void onNext({{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response value) {
+            {% if has_result %}
+            {% endif %}
 
-          {%- if return_type.is_repeated %}
-          emitter.onNext(value.get{{ return_name.upper_camel_case }}List());
-          {%- else %}
-          emitter.onNext(value.get{{ return_name.upper_camel_case }}());
-          {%- endif %}
-        }
+            {%- if return_type.is_repeated %}
+            emitter.onNext(value.get{{ return_name.upper_camel_case }}List());
+            {%- else %}
+            emitter.onNext(value.get{{ return_name.upper_camel_case }}());
+            {%- endif %}
+          }
 
-        @Override
-        public void onError(Throwable t) {
-          emitter.onError(t);
-        }
+          @Override
+          public void onError(Throwable t) {
+            emitter.onError(t);
+          }
 
-        @Override
-        public void onCompleted() {
-          emitter.onComplete();
-        }
+          @Override
+          public void onCompleted() {
+            emitter.onComplete();
+          }
+        });
       });
-    });
-  }, BackpressureStrategy.BUFFER);
+    }, BackpressureStrategy.BUFFER);
+
+  return flowable
+  .replay(1)
+  .autoConnect();
+}
+
+public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}Proto.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}Proto.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}() {
+  return {{ name.lower_camel_case }};
 }


### PR DESCRIPTION
@RyanHurst: Would you mind reviewing this PR by testing if this solves your problem before I merge?

It may not be super easy to read in the templates, but I essentially to the following:

1. Save the flowables as members, so that calls like `telemetry.armed()` always get the same object (before it was creating a new one everytime, registering a new callback to the C++ SDK).

2. Use RxJava2's `replay` and `autoConnect` operators to "share" the subscription between all the subscribers of that shared object, with:

```
.replay(1)
.autoConnect();
```

Resolves #3.