### PR TITLE
sdk: throw exception on failure result

### DIFF
--- a/sdk/templates/call.j2
+++ b/sdk/templates/call.j2
@@ -18,9 +18,16 @@ public Completable {{ name.lower_camel_case }}({% for param in params %}{{ param
         @Override
         public void onNext({{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response value) {
           {%- if has_result %}
-          {% endif %}
+          {{ plugin_name.upper_camel_case }}Result result = {{ plugin_name.upper_camel_case }}Result.translateFromRpc(value.get{{ plugin_name.upper_camel_case }}Result());
 
+          if (result.result != {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS) {
+            emitter.onError(new {{ plugin_name.upper_camel_case }}Exception(result.result, result.resultStr));
+          } else {
+            emitter.onComplete();
+          }
+          {%- else %}
           emitter.onComplete();
+          {%- endif %}
         }
 
         @Override

--- a/sdk/templates/file.j2
+++ b/sdk/templates/file.j2
@@ -43,6 +43,14 @@ public class {{ plugin_name.upper_camel_case }} {
     scheduler = Schedulers.trampoline();
   }
 
+  {% if has_result %}
+  public class {{ plugin_name.upper_camel_case }}Exception extends Exception {
+    public {{ plugin_name.upper_camel_case }}Exception({{ plugin_name.upper_camel_case }}Result.Result code, String description) {
+      super(code + ": " + description);
+    }
+  }
+  {% endif %}
+
 {%- for enum in enums %}
 {{ indent(enum, 1) }}
 {%- endfor %}

--- a/sdk/templates/request.j2
+++ b/sdk/templates/request.j2
@@ -18,12 +18,23 @@ public Single<{% if return_type.is_primitive %}{{ return_type.name }}{% elif ret
         @Override
         public void onNext({{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response value) {
           {%- if has_result %}
-          {% endif %}
+          {{ plugin_name.upper_camel_case }}Result result = {{ plugin_name.upper_camel_case }}Result.translateFromRpc(value.get{{ plugin_name.upper_camel_case }}Result());
 
-          {%- if return_type.is_repeated %}
-          emitter.onSuccess(value.get{{ return_name.upper_camel_case }}List());
+          if (result.result != {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS) {
+            emitter.onError(new {{ plugin_name.upper_camel_case }}Exception(result.result, result.resultStr));
+          } else {
+            {%- if return_type.is_repeated %}
+            emitter.onSuccess(value.get{{ return_name.upper_camel_case }}List());
+            {%- else %}
+            emitter.onSuccess(value.get{{ return_name.upper_camel_case }}());
+            {%- endif %}
+          }
           {%- else %}
+            {%- if return_type.is_repeated %}
+          emitter.onSuccess(value.get{{ return_name.upper_camel_case }}List());
+            {%- else %}
           emitter.onSuccess(value.get{{ return_name.upper_camel_case }}());
+            {%- endif %}
           {%- endif %}
         }
 

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -12,14 +12,30 @@ private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif 
 
           @Override
           public void onNext({{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Response value) {
+          {%- if has_result %}
+          {{ plugin_name.upper_camel_case }}Result result = {{ plugin_name.upper_camel_case }}Result.translateFromRpc(value.get{{ plugin_name.upper_camel_case }}Result());
+
+          switch (result.result) {
+            case SUCCESS:
+            case IN_PROGRESS:
+            case INSTRUCTION:
+              {%- if return_type.is_repeated %}
+              emitter.onNext(value.get{{ return_name.upper_camel_case }}List());
+              {%- else %}
+              emitter.onNext(value.get{{ return_name.upper_camel_case }}());
+              {%- endif %}
+            default:
+              emitter.onError(new {{ plugin_name.upper_camel_case }}Exception(result.result, result.resultStr));
+          }
+          {%- else %}
+            {%- if return_type.is_repeated %}
+          emitter.onNext(value.get{{ return_name.upper_camel_case }}List());
+            {%- else %}
+          emitter.onNext(value.get{{ return_name.upper_camel_case }}());
+            {%- endif %}
+          {%- endif %}
             {% if has_result %}
             {% endif %}
-
-            {%- if return_type.is_repeated %}
-            emitter.onNext(value.get{{ return_name.upper_camel_case }}List());
-            {%- else %}
-            emitter.onNext(value.get{{ return_name.upper_camel_case }}());
-            {%- endif %}
           }
 
           @Override


### PR DESCRIPTION
@julianoes: FYI

Some of our functions return a result, e.g. `CalibrationResult.SUCCESS` or `CalibrationResult.BUSY`.

In case of success, we just pass the element (calling the RxJava `onNext`). But in case of failure (everything that is not `SUCCESS`, `IN_PROGRESS` or `INSTRUCTION`), we throw an exception (in the RxJava sense, with `onError`).

Just as a reminder: we currently have `IN_PROGRESS` and `INSTRUCTION`, but in the future (i.e. when the C++ API gets generated), they will be merged into `NEXT`. Which means that the only success codes will ever be `SUCCESS` and `NEXT`.